### PR TITLE
get_script_path: return cwd if script path doesn't exist

### DIFF
--- a/jetpytools/utils/file.py
+++ b/jetpytools/utils/file.py
@@ -48,7 +48,8 @@ def get_script_path() -> SPath:
     import __main__
 
     try:
-        return SPath(__main__.__file__)
+        path = SPath(__main__.__file__)
+        return path if path.exists() else SPath.cwd()
     except AttributeError:
         return SPath.cwd()
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from jetpytools import get_script_path
+
+
+def test_get_script_path() -> None:
+    script_path = get_script_path()
+    assert script_path is not None
+    assert script_path.exists()


### PR DESCRIPTION
When using `get_script_path()` under uv (on Windows, at least), something like `uv run pytest` or `uv run vspreview` returns e.g. `C:/jetpytools/.venv/Scripts/pytest.exe/__main__.py`, which isn't a path that actually exists. Then things like vstools `PackageStorage` break when they try to create new files under that path. The least we can do is try to not return nonexistent paths.